### PR TITLE
Faster online list update

### DIFF
--- a/src/api/tibia/index.js
+++ b/src/api/tibia/index.js
@@ -3,10 +3,22 @@ import axios from 'axios';
 const TIBIA_DATA_API_URL = 'https://api.tibiadata.com/v2/';
 
 export default class TibiaAPI {
-  constructor(worldName) {
+  constructor({ worldName }) {
     this.worldName = worldName;
   }
   
+  async getOnlinePlayers() {
+    const {
+      data: {
+        world: {
+          players_online: playersOnline,
+        }
+      }
+    } = await axios.get(`${TIBIA_DATA_API_URL}world/${this.worldName}.json`);
+
+    return playersOnline;
+  }
+
   async getCharacterInformation(characterName) {
     const {
       data: {


### PR DESCRIPTION
Adding `tibiaAPI.getOnlinePlayers();` to get all `characters_online` by world and then just filtering them.

Sadly, The API take so long to refresh the list of online players and i do belive this is an issue from the actual "who is online" from tibia

 
Will re-visit this each weeks and see how it works